### PR TITLE
Add codespell workflow, run codespell

### DIFF
--- a/.codespell_ignore
+++ b/.codespell_ignore
@@ -1,0 +1,5 @@
+ue
+te
+extraversion
+pres
+filp

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,16 @@
+name: Codespell PR Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  codespell-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2
+        with:
+          ignore_words_file: .codespell_ignore

--- a/_articles/kernel_basics.md
+++ b/_articles/kernel_basics.md
@@ -47,7 +47,7 @@ exception which the kernel may resolve by setting up appropriate mapping (e.g. m
 Here's a short AT&T-style x86 assembly file we can use to generate a binary that will attempt to execute a privileged instruction:
 
 ```
-global _start		; declare the _start symbol to have exernal linkage for visibility of linker
+global _start		; declare the _start symbol to have external linkage for visibility of linker
 _start:				; the true entry point for an x86 executable program
 	rdmsr			; execute the RDMSR instruction
 ```

--- a/_articles/linux_basics.md
+++ b/_articles/linux_basics.md
@@ -25,17 +25,17 @@ Append these two lines to your `~/.vimrc` to auto-highlight whitespace errors in
 	* As we were about to proceed to the demo, we didn't go into great detail
 	* Take note of the availability of manpages: run `man man` and read through the description.
 * After finishing the slide deck, we build a minimal Linux distribution live
-	* Using a ruthlessly minimal `.config` file, we built the kernel in noticably less time than it took to clone, even with the `--depth=1` option. Barely minutes.
+	* Using a ruthlessly minimal `.config` file, we built the kernel in noticeably less time than it took to clone, even with the `--depth=1` option. Barely minutes.
 	* Then, we tested this kernel with `qemu-system`, generating a kernel panic as expected
-	* This is because the kernel attempts to start an inital userspace process and no such thing exists on the system
+	* This is because the kernel attempts to start an initial userspace process and no such thing exists on the system
 	* On many Linux systems, systemd is this first "init" process, and it is given PID `1`
 	* We then created a root filesystem and a "hello world" init process
 	* This native assembly simply prints hello world
 	* Take note that the entry point is `_start` and not `main`
 	* Normally this is hidden as `libc` does various init things between `_start` and the user-defined `main`
 	* We used `strace` to see how our little app talks to the kernel
-	* In order to pass the app binary into the kernel, we use `cpio` to create an archive usable as an inital ram disk for our system, which allows the kernel to run the app as an init process
-	* This is generally refered to by the abbreviation `initrd`. 
+	* In order to pass the app binary into the kernel, we use `cpio` to create an archive usable as an initial ram disk for our system, which allows the kernel to run the app as an init process
+	* This is generally referred to by the abbreviation `initrd`. 
 	* `initrd` is an area of RAM that provides a storage device interface to the rest of the kernel.
 * Since there were no questions, we attempted to make our minimal Linux distro interactive
 	* We implemented a parameter allowing a user to specify a string to print after "hello" instead of "world"

--- a/_articles/module_translation.md
+++ b/_articles/module_translation.md
@@ -821,7 +821,7 @@ $ cat include/linux/kern_levels.h
 /*
  * Annotation for a "continued" line of log printout (only done after a
  * line that had no enclosing \n). Only to be used by core/arch code
- * during early bootup (a continued line is not SMP-safe otherwise).
+ * during early boot-up (a continued line is not SMP-safe otherwise).
  */
 #define KERN_CONT	KERN_SOH "c"
 

--- a/_articles/syscall_basics.md
+++ b/_articles/syscall_basics.md
@@ -2,7 +2,7 @@
 layout: article
 title: Syscall Basics
 ---
-### C system programing interactive demo
+### C system programming interactive demo
 
 0. the most basic C program possible: `main(){}`
 

--- a/_articles/syscalls_end_to_end.md
+++ b/_articles/syscalls_end_to_end.md
@@ -53,7 +53,7 @@ for performance reasons the only actions taken by the `syscall` instruction besi
 * Saving the return address before jumping to the kernel handler:
     * The current instruction pointer `rip` is copied into `rcx`
     * The address of the kernel handler is loaded from the `LSTAR` model specific register into `rip`
-* Saving the current processor flags before reseting them to a known value
+* Saving the current processor flags before resetting them to a known value
     * The current flags `RFLAGS` are copied into `r11`
     * The flags register is adjusted with a bitmask from the `FMASK` model specific register
 

--- a/_articles/topics.md
+++ b/_articles/topics.md
@@ -16,7 +16,7 @@ What is a Unix-like Operating System?
 --
 
 - Linux vs Unix & history: where does Linux come from?
-- building a distro, minimal distro ("aparatus")
+- building a distro, minimal distro ("apparatus")
 - what is a Linux process, syscall basics, file descriptor intro
 - e.g. grep in a child process (bill cs308 assignment 2)
 - open read write fork exec dup pipe wait close exit
@@ -28,9 +28,9 @@ Hardware meets software
 - What is CPU privilege
   - trying to execute forbidden instructions (rdmsr_priv_demo)
   - kernel abilities vs userspace
-- exceptions: traps, interupts, aborts
+- exceptions: traps, interrupts, aborts
 - featured example: Syscalls end-to-end
-  - tracing a syscall intruction from the invocation
+  - tracing a syscall instruction from the invocation
   - ??? stuff happens ???
   - response back to userspace
 

--- a/_slides/concurrency.html
+++ b/_slides/concurrency.html
@@ -116,7 +116,7 @@ title: Concurrency
 <ul>
 <li>spinlock
 <ul>
-<li>locking primitive that can be used to implement all other forms of mutual exlcusion</li>
+<li>locking primitive that can be used to implement all other forms of mutual exclusion</li>
 </ul>
 </li>
 <li>semaphore

--- a/_slides/git.html
+++ b/_slides/git.html
@@ -200,7 +200,7 @@ $ git merge feature1</p>
 $ git merge --squash feature1<br />
 # Make some changes<br />
 $ git add . &amp;&amp; git commit -m &quot;some message&quot;</li>
-<li>This allows you to make some more changes before you commmit your merge</li>
+<li>This allows you to make some more changes before you commit your merge</li>
 </ul>
 </section>
 </foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="24">

--- a/_slides/interrupts.html
+++ b/_slides/interrupts.html
@@ -73,7 +73,7 @@ CPU0         CPU1<br />
 </li>
 <li>void local_irq_save(unsigned long flags);, void local_irq_disable(void);
 <ul>
-<li>Diable all interrupts</li>
+<li>Disable all interrupts</li>
 </ul>
 </li>
 <li>void local_irq_restore(unsigned long flags);, void local_irq_enable(void);
@@ -117,7 +117,7 @@ CPU0         CPU1<br />
 <li>Interrupt handlers should return a value indicating whether there was an actual interrupt to handle
 <ul>
 <li>IRQ_HANDLED if the IRQ was able to be handled by the top half</li>
-<li>IRQ_WAKE_THREAD if the bottom half shold be scheduled</li>
+<li>IRQ_WAKE_THREAD if the bottom half should be scheduled</li>
 <li>IRQ_NONE if there was nothing to handle (or IRQ wasn’t from device)</li>
 </ul>
 </li>

--- a/_slides/writing_modules.html
+++ b/_slides/writing_modules.html
@@ -90,7 +90,7 @@ module_exit(hello_exit);
 <h1>Why not stick with userspace?</h1>
 <ul>
 <li>Context switches makes response time slower</li>
-<li>Access to hardware requires priveledged instructions
+<li>Access to hardware requires privileged instructions
 <ul>
 <li>The most important drivers can’t be handled in user space</li>
 </ul>

--- a/course/fall2023/assignments/E0.md
+++ b/course/fall2023/assignments/E0.md
@@ -9,7 +9,7 @@ Build, install, and boot the latest Linux kernel fresh off Linus Torvalds’ tre
 #### What to submit:
 
 * Make a copy of `template.txt` in the assignment directory renamed to `firstname_lastname.txt`.
-  Edit it as nescessary (don't forget to include the output of `uname -a` and `dmesg | head` and `whoami`
+  Edit it as necessary (don't forget to include the output of `uname -a` and `dmesg | head` and `whoami`
   on the system running your newly compiled Linux kernel.)  and make a commit out of it.
 * Generate your patches.
 * Don’t forget a cover letter.

--- a/course/fall2023/assignments/final_pres_guide.md
+++ b/course/fall2023/assignments/final_pres_guide.md
@@ -20,7 +20,7 @@ and give the instructors feedback.
 	- How does your work fit into the big picture of...?
 		- Your academic career
 		- Your software engineering skill development
-		- Your understanding of open source sofware
+		- Your understanding of open source software
 	- What assignments did you particularly enjoy or not enjoy?
         - Explain why your felt that way
         - For those you enjoyed, how could you go further?

--- a/course/fall2023/assignments/setup.md
+++ b/course/fall2023/assignments/setup.md
@@ -124,7 +124,7 @@ If you see this, you have completed the basic installation of Fedora correctly. 
     * Make a commit to save this version of the repository so it can be shared. Run `git commit -s`.
         * the `-s` flag makes git include the `Signed-off-by` DCO line for you automatically.
     * Git will open an instance of your preferred text editor to let you input a message for the commit.
-        * Put a title containing a short summay of what you did on the first line (e.g. `Introductions: Added introduction for so and so`).
+        * Put a title containing a short summary of what you did on the first line (e.g. `Introductions: Added introduction for so and so`).
         * Press enter twice and write a more detailed explanation that will act as the body of the commit.
         * There should already be a signed off by DCO line for your account at the bottom. If not, add one.
         * Save your changes and exit the editor to finish the commit.
@@ -136,7 +136,7 @@ If you see this, you have completed the basic installation of Fedora correctly. 
         * `-1` means include the most recent 1 commit
         * `--cover-letter` means generate a cover letter for the whole patch series with a summary
         * `-v1` means mark this as the first version of this patch set
-        * `--rfc` means mark these patches as a request for comment. This is required for all intial submissions since they will be recieving peer feedback.
+        * `--rfc` means mark these patches as a request for comment. This is required for all initial submissions since they will be receiving peer feedback.
     * Git will generate two `.patch` files for you.
     * Edit the file `v1-0000-cover-letter.patch` and write your cover letter.
         * Follow the directions in the assignment submission guidelines
@@ -144,10 +144,10 @@ If you see this, you have completed the basic installation of Fedora correctly. 
 * Send your patches to the class mailing list.
     * Run the command `git send-email --to=introductions@kdlp.underground.software v1*.patch`
         * Each assignment will have its own special address to send submissions to. In this case it is `introductions@kdlp.underground.software`
-        * the expression `v1*.patch` will be exapanded by the shell into all file names matchin that pattern (any file whose name starts with `v1` and ends with `.patch`)
+        * the expression `v1*.patch` will be expanded by the shell into all file names matching that pattern (any file whose name starts with `v1` and ends with `.patch`)
     * Git send email will prompt you to ask whether it should send the emails. Type `a` and hit enter to send them all.
         * If it is successful, the output should end with `Result: 250` which indicates that the server accepted your emails.
-        * If it does not work. Do not hesistate to reach out and we can help with troubleshooting.
+        * If it does not work. Do not hesitate to reach out and we can help with troubleshooting.
 
 #### Check your work
 * While Logged in as your non root user account

--- a/course/fall2023/index.md
+++ b/course/fall2023/index.md
@@ -12,13 +12,13 @@ Linux is the most widely used operating system in the world. The core software c
 
 Students will:
 
-* Stretch their C programing skills to the limit
+* Stretch their C programming skills to the limit
 
 * Create, develop, and test interesting and creative Linux kernel modules
 
 * Develop the ability to autonomously participate in the open source software community
 
-* Learn how to give and recieve feedback on code patches
+* Learn how to give and receive feedback on code patches
 
 * Demonstrate the ability to explain your code and your knowledge of Linux in your own words
 

--- a/course/fall2023/lectures/L00.md
+++ b/course/fall2023/lectures/L00.md
@@ -23,7 +23,7 @@ See [this](../policies/course_policies.md) page
 
 #### Breakdown of grading
 
-The formatting was incorrect on the course page during class. It has since been fixed, but it has been replicated here for your convinience:
+The formatting was incorrect on the course page during class. It has since been fixed, but it has been replicated here for your convenience:
 
 Student grades will be weighted according to the following scheme:
 

--- a/course/fall2023/lectures/L01.md
+++ b/course/fall2023/lectures/L01.md
@@ -4,14 +4,14 @@
 
 * Questions on setup
 * Introduction to E0 & P0
-* C system programing interactive demo
+* C system programming interactive demo
 
 
 ### Questions on setup
 
 * For clarification: git repositories are read-only for students
 
-* If this setup or C programing is overwhelming, this course may not be right for you
+* If this setup or C programming is overwhelming, this course may not be right for you
 
 ### Introduction to E0 & P0
 
@@ -25,7 +25,7 @@ See [this video](https://www.youtube.com/watch?v=zYB72Rnz3TA) for more guidance 
 
 See [this video](https://www.youtube.com/watch?v=JqljsuVaUIU) for more guidance on how to complete P0.
 
-### C system programing interactive demo
+### C system programming interactive demo
 
 0. the most basic C program possible: `main(){}`
 

--- a/course/fall2023/lectures/L04.md
+++ b/course/fall2023/lectures/L04.md
@@ -59,17 +59,17 @@ Append these two lines to your `~/.vimrc` to auto-highlight whitespace errors in
 	* As we were about to proceed to the demo, we didn't go into great detail
 	* Take note of the availability of manpages: run `man man` and read through the description.
 * After finishing the slide deck, we build a minimal Linux distribution live
-	* Using a ruthlessly minimal `.config` file, we built the kernel in noticably less time than it took to clone, even with the `--depth=1` option. Barely minutes.
+	* Using a ruthlessly minimal `.config` file, we built the kernel in noticeably less time than it took to clone, even with the `--depth=1` option. Barely minutes.
 	* Then, we tested this kernel with `qemu-system`, generating a kernel panic as expected
-	* This is because the kernel attempts to start an inital userspace process and no such thing exists on the system
+	* This is because the kernel attempts to start an initial userspace process and no such thing exists on the system
 	* On many Linux systems, systemd is this first "init" process, and it is given PID `1`
 	* We then created a root filesystem and a "hello world" init process
 	* This native assembly simply prints hello world
 	* Take note that the entry point is `_start` and not `main`
 	* Normally this is hidden as `libc` does various init things between `_start` and the user-defined `main`
 	* We used `strace` to see how our little app talks to the kernel
-	* In order to pass the app binary into the kernel, we use `cpio` to create an archive usable as an inital ram disk for our system, which allows the kernel to run the app as an init process
-	* This is generally refered to by the abbreviation `initrd`. 
+	* In order to pass the app binary into the kernel, we use `cpio` to create an archive usable as an initial ram disk for our system, which allows the kernel to run the app as an init process
+	* This is generally referred to by the abbreviation `initrd`. 
 	* `initrd` is an area of RAM that provides a storage device interface to the rest of the kernel.
 * Since there were no questions, we attempted to make our minimal Linux distro interactive
 	* We implemented a parameter allowing a user to specify a string to print after "hello" instead of "world"

--- a/course/fall2023/lectures/L05.md
+++ b/course/fall2023/lectures/L05.md
@@ -41,7 +41,7 @@
 Here's a short AT&T-style x86 assembly file we can use to generate a binary that will attempt to execute a privileged instruction:
 
 ```
-global _start		; declare the _start symbol to have exernal linkage for visibility of linker
+global _start		; declare the _start symbol to have external linkage for visibility of linker
 _start:				; the true entry point for an x86 executable program
 	rdmsr			; execute the RDMSR instruction
 ```

--- a/course/fall2023/lectures/L08.md
+++ b/course/fall2023/lectures/L08.md
@@ -9,7 +9,7 @@ The instructors are willing to spend more time helping students who take initiat
 
 * You have thoroughly read the assignment instructions
 * You have proofread your command or code for typos
-* If something has failed, you have read the error messsage and you have it ready to send to the instructor
+* If something has failed, you have read the error message and you have it ready to send to the instructor
 * You read any relevant man pages or documentation
 * You have searched the web for solutions
 

--- a/course/fall2023/lectures/L09.md
+++ b/course/fall2023/lectures/L09.md
@@ -14,7 +14,7 @@ for performance reasons the only actions taken by the `syscall` instruction besi
 * Saving the return address before jumping to the kernel handler:
     * The current instruction pointer `rip` is copied into `rcx`
     * The address of the kernel handler is loaded from the `LSTAR` model specific register into `rip`
-* Saving the current processor flags before reseting them to a known value
+* Saving the current processor flags before resetting them to a known value
     * The current flags `RFLAGS` are copied into `r11`
     * The flags register is adjusted with a bitmask from the `FMASK` model specific register
 

--- a/course/fall2023/lectures/L12.md
+++ b/course/fall2023/lectures/L12.md
@@ -1,6 +1,6 @@
 # Lecture 12 - 19 October 2023
 
 ## Topics Covered:
-* non-permission mode bits (i.e. setuid setgit and sticky)
+* non-permission mode bits (i.e. setuid setgid and sticky)
 * Using procfs to avoid race condition
 * Writing Basic Linux Kernel Module

--- a/course/fall2023/lectures/L14.md
+++ b/course/fall2023/lectures/L14.md
@@ -1,6 +1,6 @@
 # Lecture 14 - 26 October 2023
 
 ## Topics Covered:
-* Background: Privelege escalation and course email infrastructure
+* Background: Privilege escalation and course email infrastructure
 * Chroot system call
 * Dynamic linking

--- a/course/fall2023/lectures/L17.md
+++ b/course/fall2023/lectures/L17.md
@@ -837,7 +837,7 @@ $ cat include/linux/kern_levels.h
 /*
  * Annotation for a "continued" line of log printout (only done after a
  * line that had no enclosing \n). Only to be used by core/arch code
- * during early bootup (a continued line is not SMP-safe otherwise).
+ * during early boot-up (a continued line is not SMP-safe otherwise).
  */
 #define KERN_CONT	KERN_SOH "c"
 

--- a/course/fall2023/policies/course_policies.md
+++ b/course/fall2023/policies/course_policies.md
@@ -36,7 +36,7 @@
     * If the student approves of a submission, then the student will reply to the approved email with what we call an "ack".
       * An "ack" consists of a single line containing the following: Acked-by: Firstname Lastname <email@domain.tld\>.
     * If the student sees problems with a submission, the student will reply to the problematic email with their feedback.
-    * In parallel, other students have been assigned the student's submission and the student should recieve feedback from two other students.
+    * In parallel, other students have been assigned the student's submission and the student should receive feedback from two other students.
     * These reviews are due one day past the initial submission, a late or no submission results in a zero for the review section of the assignment.
     * Reviews are graded based on how many issues a student missed.
       * The student receives 20% off for each unique issue not spotted with max penalty of 100%.
@@ -45,7 +45,7 @@
     * Regardless of whether the student made changes to their initial submission, they must make a final submission.
     * This is due two days after the initial submission, and due one day after receiving the reviews.
   * Overall assignment grading scheme (percentages are relative to the total assignment grade):
-    * The initial submission is purely for the peer-review process. It is crucial that the initial submission is made on time, otherwise, as stated above, the student will recieve a zero on the entire assignment.
+    * The initial submission is purely for the peer-review process. It is crucial that the initial submission is made on time, otherwise, as stated above, the student will receive a zero on the entire assignment.
     * Review 1: 10%
     * Review 2: 10%
     * Final Submission: 80%

--- a/course/fall2023/policies/submission_guidelines.md
+++ b/course/fall2023/policies/submission_guidelines.md
@@ -22,7 +22,7 @@ $ # generates patches from the three most recent commits (change -3 to whatever 
 
 All of the patches must follow the patch guidelines [1]. Those generated from a commit should follow the commit guidelines [2] and the cover letter must follow the cover letter guidelines [3].
 
-You will recieve an automatic zero on the assignment if any of the patches in your patchset are corrupt. This shouldn't be possible if you generate your patches with `git format-patch`, but if you edit the files manually they might get corrupted. You have been warned! The correct way to edit the patches is to edit the underlying commits (see `man git-rebase` and the `--amend` option from `man git-commit`) and then regenerate the patches. 
+You will receive an automatic zero on the assignment if any of the patches in your patchset are corrupt. This shouldn't be possible if you generate your patches with `git format-patch`, but if you edit the files manually they might get corrupted. You have been warned! The correct way to edit the patches is to edit the underlying commits (see `man git-rebase` and the `--amend` option from `man git-commit`) and then regenerate the patches. 
 
 #### [1] Patch Guidelines
 

--- a/course/spring2023/assignments/A1.md
+++ b/course/spring2023/assignments/A1.md
@@ -12,7 +12,7 @@ The objective of this assignment is to build a UNIX style shell.
 
 * This assignment will guide you through the process of building a shell by iteratively improving your code and adding more features, starting with a very simple program. At the end you should have a shell that mostly works.
 * You must make at least one commit per level completed, and label clearly at which commit you think you completed a particular level.
-* You must pass all ten levels listed below. If you want to go further for an extra challange, see the list of ideas at the bottom.
+* You must pass all ten levels listed below. If you want to go further for an extra challenge, see the list of ideas at the bottom.
 
 #### What to submit:
 
@@ -38,7 +38,7 @@ The objective of this assignment is to build a UNIX style shell.
   * However, if the user just hits enter without typing anything, no error message is printed.
 * **lvl 3:**
   * The shell splits the line of input into pieces delimited by whitespace characters (see `man 3 isspace`).
-  * Instead of just printing "Unrecognized commmand" the shell shall include the name of the program in the error message (e.g. if the user types `cat shell.c`, the shell prints "Unrecognized commmand: cat").
+  * Instead of just printing "Unrecognized command" the shell shall include the name of the program in the error message (e.g. if the user types `cat shell.c`, the shell prints "Unrecognized command: cat").
 * **lvl 4:**
   * the shell supports a few builtin commands (exit, cd and exec). If the first piece of the input is not "exit" or "cd" or "exec" it will still print the unrecognized command message, otherwise:
     * exit: takes no arguments (prints error if they are provided) and closes the shell (return value of 0)
@@ -61,7 +61,7 @@ The objective of this assignment is to build a UNIX style shell.
   * A redirection beginning with `>` behaves similarly, but it replaces the stdout of the process.
 * **lvl 9:**
   * The shell supports the `|` (pipe) operator to chain multiple commands and their inputs and outputs.
-  * Each command seperated by a `|` is spawned as its own child process. The shell can handle more than one pipe.
+  * Each command separated by a `|` is spawned as its own child process. The shell can handle more than one pipe.
   * The shell creates a unidirectional pipe (see `man 2 pipe`) for each `|` and redirects the stdout from the left command to the writing end of the pipe and redirects the stdin of the right command to the reading end of the pipe.
   * Any file redirections specified by the user take precedence over any implied redirections of the `|`.
 

--- a/course/spring2023/assignments/A3.md
+++ b/course/spring2023/assignments/A3.md
@@ -7,7 +7,7 @@ Add a new system call to the kernel
 * Get comfortable with the concept of a syscall from both kernelspace and userspace
   * Learn how userspace programs make systemcalls
   * Learn how those calls are handled by the kernel
-* Understand how C relates to assembly languge
+* Understand how C relates to assembly language
   * Write a C program to call your systemcall
   * Write the same program in the assembly language of your platform
 
@@ -19,7 +19,7 @@ Add a new system call to the kernel
 
   	b) The function copies a string into the userspace buffer containing the student's name and the name of the executable binary that is running.
 
-	c) The function returns the length of the string copied upon sucess. If there is an issue with the size of the provided buffer, checked by proxy of the `size_t` argument, then the function returns `-EFAULT` to the user.
+	c) The function returns the length of the string copied upon success. If there is an issue with the size of the provided buffer, checked by proxy of the `size_t` argument, then the function returns `-EFAULT` to the user.
 
 	d) The function should take care to prevent any possibility of a buffer overflow.
 

--- a/course/spring2023/assignments/course_application.md
+++ b/course/spring2023/assignments/course_application.md
@@ -24,7 +24,7 @@ e) If you have a resume, KDLP allows that it be attached to this email as a PDF 
 
 f) The email must contain your discord username that you will use to complete step 2
 
-g) If you prefer to use a different email to send and recieve email patches on our mailing list than the one you are using to send this message, you should specify this address. KDLP will provide instructions on the usage of gmail with our systems, but it is not required that all students use gmail.
+g) If you prefer to use a different email to send and receive email patches on our mailing list than the one you are using to send this message, you should specify this address. KDLP will provide instructions on the usage of gmail with our systems, but it is not required that all students use gmail.
 
 h) Include your time zone.
 

--- a/course/spring2023/assignments/vm_instructions.md
+++ b/course/spring2023/assignments/vm_instructions.md
@@ -1,5 +1,5 @@
 ### How to set up your VM and Linux environment
-Start downloading the standard ISO image for Fedora for your architechture (most likely it would be x86_64, unless you have an M1 Mac or you are running Linux on ARM in which case you want the aarch64 ISO): <https://getfedora.org/en/server/download/>. This may take a while, depending on your connection, so get this started first.
+Start downloading the standard ISO image for Fedora for your architecture (most likely it would be x86_64, unless you have an M1 Mac or you are running Linux on ARM in which case you want the aarch64 ISO): <https://getfedora.org/en/server/download/>. This may take a while, depending on your connection, so get this started first.
 
 #### Get the appropriate software
 * Windows - [VirtualBox](https://www.virtualbox.org/wiki/Downloads):

--- a/course/spring2023/index.md
+++ b/course/spring2023/index.md
@@ -12,13 +12,13 @@ Linux is the most widely used operating system in the world. The core software c
 
 Students will:
 
-* Stretch their C programing skills to the limit
+* Stretch their C programming skills to the limit
 
 * Create, develop, and test interesting and creative Linux kernel modules
 
 * Develop the ability to autonomously participate in the open source software community
 
-* Learn how to give and recieve feedback on code patches
+* Learn how to give and receive feedback on code patches
 
 * Demonstrate the ability to explain your code and your knowledge of Linux in your own words
 

--- a/course/spring2023/lectures/L18.md
+++ b/course/spring2023/lectures/L18.md
@@ -6,4 +6,4 @@ Class notes:
 
 * This is a re-recording of the lecture, due to gmeet technical difficulties.
 * The lecture goes over the end of the echo driver.
-* We started a driver debugging excersize that we mention in the recording, the continuation will be on Monday's lecture.
+* We started a driver debugging exercise that we mention in the recording, the continuation will be on Monday's lecture.

--- a/course/spring2023/lectures/L19.md
+++ b/course/spring2023/lectures/L19.md
@@ -5,4 +5,4 @@
 Class Notes:
 
 * Talk about the rest of the course, final presentations, and last two assignments.
-* Finished the debugging excersize.
+* Finished the debugging exercise.

--- a/course/spring2023/policies/course_policies.md
+++ b/course/spring2023/policies/course_policies.md
@@ -36,7 +36,7 @@
     * If the student approves of a submission, then the student will reply to the approved email with what we call an "ack".
       * An "ack" consists of a single line containing the following: Acked-by: Firstname Lastname <email@domain.tld\>.
     * If the student sees problems with a submission, the student will reply to the problematic email with their feedback.
-    * In parallel, other students have been assigned the student's submission and the student should recieve feedback from two other students.
+    * In parallel, other students have been assigned the student's submission and the student should receive feedback from two other students.
     * These reviews are due one day past the initial submission, a late or no submission results in a zero for the review section of the assignment.
     * Reviews are graded based on how many issues a student missed.
       * The student receives 20% off for each unique issue not spotted with max penalty of 100%.
@@ -45,7 +45,7 @@
     * Regardless of whether the student made changes to their initial submission, they must make a final submission.
     * This is due two days after the initial submission, and due one day after receiving the reviews.
   * Overall assignment grading scheme (percentages are relative to the total assignment grade):
-    * The initial submission is purely for the peer-review process. It is crucial that the initial submission is made on time, otherwise, as stated above, the student will recieve a zero on the entire assignment.
+    * The initial submission is purely for the peer-review process. It is crucial that the initial submission is made on time, otherwise, as stated above, the student will receive a zero on the entire assignment.
     * Review 1: 10%
     * Review 2: 10%
     * Final Submission: 80%

--- a/course/spring2023/policies/submission_guidelines.md
+++ b/course/spring2023/policies/submission_guidelines.md
@@ -22,7 +22,7 @@ $ # generates patches from the three most recent commits (change -3 to whatever 
 
 All of the patches must follow the patch guidelines [1]. Those generated from a commit should follow the commit guidelines [2] and the cover letter must follow the cover letter guidelines [3].
 
-You will recieve an automatic zero on the assignment if any of the patches in your patchset are corrupt. This shouldn't be possible if you generate your patches with `git format-patch`, but if you edit the files manually they might get corrupted. You have been warned! The correct way to edit the patches is to edit the underlying commits (see `man git-rebase` and the `--amend` option from `man git-commit`) and then regenerate the patches. 
+You will receive an automatic zero on the assignment if any of the patches in your patchset are corrupt. This shouldn't be possible if you generate your patches with `git format-patch`, but if you edit the files manually they might get corrupted. You have been warned! The correct way to edit the patches is to edit the underlying commits (see `man git-rebase` and the `--amend` option from `man git-commit`) and then regenerate the patches. 
 
 #### [1] Patch Guidelines
 

--- a/faq.md
+++ b/faq.md
@@ -10,7 +10,7 @@ Q: How can I stay informed about this program?
 
 A:
 [Join our mailing list](https://groups.google.com/forum/#!forum/rh-kdlp/join)
-to recieve our triannual newsletter.
+to receive our triannual newsletter.
 
 Q: Who created and runs this program?
 
@@ -18,7 +18,7 @@ A: KDLP was created and developed by
 [Joel Savitz](https://joelsavitz.com)
 and
 [Charles Mirabile](https://github.com/charliemirabile)
-who run this program and actively teach the Introduction to Linux Kenrel Development course.
+who run this program and actively teach the Introduction to Linux Kernel Development course.
 
 We would like to thank the following people for their past and ongoing contributions to KDLP:
 

--- a/index.md
+++ b/index.md
@@ -32,7 +32,7 @@ Current offerings:
 * Check out our
 [course](/course/index)
 page for more information about when and where we offer Intro to Linux Kernel Development.
-* Rado Vrbosky, who will be running the course at Masaryk Univeristy in Brno, CZ this fall
+* Rado Vrbosky, who will be running the course at Masaryk University in Brno, CZ this fall
 will be giving a
 [talk](https://pretalx.com/devconf-cz-2024/talk/XSXKCT/)
 at

--- a/slides_src/concurrency.md
+++ b/slides_src/concurrency.md
@@ -92,7 +92,7 @@ theme: white
 
 # Locking Data Structures
 - spinlock
-  - locking primitive that can be used to implement all other forms of mutual exlcusion
+  - locking primitive that can be used to implement all other forms of mutual exclusion
 - semaphore
   - Combination of integer value and two functions for increment and decrement (v,p)
 - mutex

--- a/slides_src/git.md
+++ b/slides_src/git.md
@@ -188,7 +188,7 @@ $ git merge feature1
 $ git merge --squash feature1
 \# Make some changes
 $ git add . && git commit -m "some message"
-- This allows you to make some more changes before you commmit your merge
+- This allows you to make some more changes before you commit your merge
 
 ---
 

--- a/slides_src/interrupts.md
+++ b/slides_src/interrupts.md
@@ -52,7 +52,7 @@ CPU0         CPU1
 - void {disable_irq, disable_irq_nosync, enable_irq}(int irq);
   - Used to disable a single interrupt
 - void local_irq_save(unsigned long flags);, void local_irq_disable(void);
-  - Diable all interrupts
+  - Disable all interrupts
 - void local_irq_restore(unsigned long flags);, void local_irq_enable(void);
   - Restores interrupts
 
@@ -83,7 +83,7 @@ CPU0         CPU1
 - Irq is the interrupt number, dev_id is a short of client data
 - Interrupt handlers should return a value indicating whether there was an actual interrupt to handle
   - IRQ_HANDLED if the IRQ was able to be handled by the top half
-  - IRQ_WAKE_THREAD if the bottom half shold be scheduled
+  - IRQ_WAKE_THREAD if the bottom half should be scheduled
   - IRQ_NONE if there was nothing to handle (or IRQ wasn’t from device)
 
 ---

--- a/slides_src/writing_modules.md
+++ b/slides_src/writing_modules.md
@@ -69,7 +69,7 @@ module_exit(hello_exit);
 
 # Why not stick with userspace?
 - Context switches makes response time slower
-- Access to hardware requires priveledged instructions
+- Access to hardware requires privileged instructions
     - The most important drivers can’t be handled in user space
 
 ---


### PR DESCRIPTION
You guys mentioned github actions in today's lecture, so I figured I could make one.

This PR adds:
- A [codespell](https://github.com/codespell-project/actions-codespell) workflow. There's one on the github actions marketplace, so its easy enough to use that
- A `.codespell_ignore` file for things that aren't typos. I note the reasoning for each in the commit as well, but `ue`, `te` are html variables. The others are abbreviations.
- Fixes for all of the existing typos in the repo. I've gone through these and believe they are correct.

